### PR TITLE
Products viewable on home and products tab, product details

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -14,7 +14,7 @@ export default function NavBar() {
     <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
       <Container>
         <Link passHref href="/">
-          <Navbar.Brand>CHANGE ME</Navbar.Brand>
+          <Navbar.Brand>BANGAZON</Navbar.Brand>
         </Link>
         <Navbar.Toggle aria-controls="responsive-navbar-nav" />
         <Navbar.Collapse id="responsive-navbar-nav">
@@ -23,8 +23,17 @@ export default function NavBar() {
             <Link passHref href="/">
               <Nav.Link>Home</Nav.Link>
             </Link>
-            <Link passHref href="/delete-me">
-              <Nav.Link>Delete Me</Nav.Link>
+            <Link passHref href="/sellers">
+              <Nav.Link>Sellers</Nav.Link>
+            </Link>
+            <Link passHref href="/products">
+              <Nav.Link>Products</Nav.Link>
+            </Link>
+            <Link passHref href="/user-profile">
+              <Nav.Link>Profile</Nav.Link>
+            </Link>
+            <Link passHref href="/cart">
+              <Nav.Link>Cart</Nav.Link>
             </Link>
             <Button variant="danger" onClick={signOut}>
               Sign Out

--- a/components/ProductCard.js
+++ b/components/ProductCard.js
@@ -1,7 +1,49 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import Link from 'next/link';
+import { Image } from 'react-bootstrap';
 
-export default function ProductCard() {
+export default function ProductCard({ product }) {
   return (
-    <div />
+    <Link passHref href={`/products/${product.id}`}>
+      <div className="product-card">
+        <Image className="pc-image" src={product.imageUrl || 'https://fl-1.cdn.flockler.com/embed/no-image.svg'} />
+        <div className="pc-info">
+          <div className="pc-title">
+            {product.title}
+          </div>
+          <div className="pc-seller">
+            by&nbsp;
+            <Link passHref href={`/sellers/${product.seller.id}`}>
+              {product.seller.username}
+            </Link>
+          </div>
+          <div className="pc-price">
+            ${product.price.toFixed(2)}
+          </div>
+          <div className="pc-category">
+            in {product.category.name}
+          </div>
+        </div>
+      </div>
+    </Link>
   );
 }
+
+ProductCard.propTypes = {
+  product: PropTypes.shape({
+    id: PropTypes.number,
+    title: PropTypes.string,
+    imageUrl: PropTypes.string,
+    price: PropTypes.number,
+    sold: PropTypes.number,
+    category: PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    }),
+    seller: PropTypes.shape({
+      id: PropTypes.number,
+      username: PropTypes.string,
+    }),
+  }).isRequired,
+};

--- a/components/ProductDetails.js
+++ b/components/ProductDetails.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Image } from 'react-bootstrap';
+import Link from 'next/link';
+
+export default function ProductDetails({ product }) {
+  return (
+    <div className="product-details">
+      <div className="header">
+        {product.title}
+      </div>
+      <div className="pd-product">
+        <Image className="pd-image" src={product.imageUrl || 'https://fl-1.cdn.flockler.com/embed/no-image.svg'} />
+        <div className="pd-info">
+          <div className="pd-description">{product.description}</div>
+          <div>
+            <div className="pd-price">
+              ${product.price.toFixed(2)}
+            </div>
+            <div className="pd-quantity">&nbsp;{product.quantity} available from&nbsp;</div>
+            <div className="pd-seller">
+              <Link passHref href={`/sellers/${product.seller.id}`}>
+                {product.seller.username}
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ProductDetails.propTypes = {
+  product: PropTypes.shape({
+    id: PropTypes.number,
+    title: PropTypes.string,
+    description: PropTypes.string,
+    imageUrl: PropTypes.string,
+    quantity: PropTypes.number,
+    price: PropTypes.number,
+    category: PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    }),
+    seller: PropTypes.shape({
+      id: PropTypes.number,
+      username: PropTypes.string,
+    }),
+  }).isRequired,
+};

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,26 +1,22 @@
-import { Button } from 'react-bootstrap';
-import { signOut } from '../utils/auth';
-import { useAuth } from '../utils/context/authContext';
+import { useEffect, useState } from 'react';
+import { getTopProducts } from '../api/productData';
+import ProductCard from '../components/ProductCard';
 
 function Home() {
-  const { user } = useAuth();
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    getTopProducts().then(setProducts);
+  }, []);
+
   return (
-    <div
-      className="text-center d-flex flex-column justify-content-center align-content-center"
-      style={{
-        height: '90vh',
-        padding: '30px',
-        maxWidth: '400px',
-        margin: '0 auto',
-      }}
-    >
-      <h1>Hello {user.fbUser.displayName}! </h1>
-      <p>Your Bio: {user.bio}</p>
-      <p>Click the button below to logout!</p>
-      <Button variant="danger" type="button" size="lg" className="copy-btn" onClick={signOut}>
-        Sign Out
-      </Button>
-    </div>
+    <>
+      <div className="header">Best Sellers</div>
+      <div className="product-container">
+        {products.length > 0
+          && products.map((p) => (<ProductCard key={p.id} product={p} />))}
+      </div>
+    </>
   );
 }
 

--- a/pages/products.js
+++ b/pages/products.js
@@ -1,9 +1,21 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { getAllProducts } from '../api/productData';
+import ProductCard from '../components/ProductCard';
 
 export default function BrowseProducts() {
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    getAllProducts().then(setProducts);
+  }, []);
+
   return (
-    <div>
-      All Products
-    </div>
+    <>
+      <div className="header">All Products</div>
+      <div className="product-container">
+        {products.length > 0
+          && products.map((p) => (<ProductCard key={p.id} product={p} />))}
+      </div>
+    </>
   );
 }

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -1,9 +1,19 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import ProductDetails from '../../components/ProductDetails';
+import { getSingleProduct } from '../../api/productData';
 
-export default function ProductDetails() {
+export default function ProductViewer() {
+  const [product, setProduct] = useState({});
+  const router = useRouter();
+
+  useEffect(() => {
+    getSingleProduct(router.query.id).then(setProduct);
+  }, []);
+
   return (
-    <div>
-      Product Details
-    </div>
+    <>
+      {product.id && (<ProductDetails product={product} />)}
+    </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,5 +18,87 @@ a {
 }
 
 body {
-  background-color: #88effd;
+  background-color: rgb(235, 235, 235);
+}
+
+.header {
+  width: 100%;
+  text-align: center;
+  font-size: 3rem;
+  font-family: Cochin, Georgia, Times, 'Times New Roman', serif;
+}
+
+.product-container {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 20px;
+  justify-content: center;
+}
+
+.product-card {
+  display: flex;
+  width: 350px;
+  height: 100px;
+  background: white;
+  border-radius: 5px;
+  border: 1px solid black;
+  .pc-image {
+    height: 100%;
+    width: 100px;
+    object-fit: contain;
+    border-radius: 5px 0 0 5px;
+  }
+  .pc-info {
+    padding: 5px;
+    width: 250px;
+  }
+  .pc-seller {
+    display: block;
+    font-size: 0.8rem;
+    a:hover {
+      color: darkgray;
+    }
+  }
+  .pc-price {
+    display: inline;
+    margin-right: 4px;
+  }
+  .pc-category {
+    display: inline;
+    font-size: 0.8rem;
+  }
+}
+
+.product-card:hover {
+  box-shadow: 1px 1px 0 gray;
+  cursor: pointer;
+}
+
+.product-details {
+  .pd-product {
+    display: flex;
+    gap: 20px;
+    .pd-image {
+      width: 40%;
+      max-width: 300px;
+      max-height: 500px;
+      object-fit: contain;
+      background: white;
+      border: 1px solid black;
+      border-radius: 10px;
+    }
+    .pd-info {
+      flex-grow: 1;
+      .pd-description {
+        font-size: 1.3rem;
+        font-style: italic;
+      }
+      .pd-quantity, .pd-seller {
+        display: inline-block;
+      }
+      .pd-price {
+        font-size: 2rem;
+      }
+    }
+  }
 }

--- a/utils/ViewDirector.js
+++ b/utils/ViewDirector.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
 import { useAuth } from './context/authContext';
 import Loading from '../components/Loading';
 import Signin from '../components/Signin';
@@ -8,10 +7,6 @@ import RegisterForm from '../components/RegisterForm';
 
 const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) => {
   const { user, userLoading, updateUser } = useAuth();
-
-  useEffect(() => {
-    console.warn(user);
-  }, [user]);
 
   // if user state is null, then show loader
   if (userLoading) {


### PR DESCRIPTION
Addressed issues #5 and #13

Built /, /products, and /products/[id] routes
Built ProductCard and ProductDetails components
Clicking on ProductCard will direct user to ProductDetails page
Clicking on a seller's name anywhere redirects to seller's storefront (not yet built)

Expanded NavBar with necessary links
Styling changes
Removed dev console.warn from ViewDirector